### PR TITLE
initialize using the parentElement when the wrap option is set.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,10 @@ class DateTimePicker extends Component {
         onChange: this.props.onChange
     }
 
-    this.flatpickr = new Flatpickr(node, options)
+
+    const flatpickrNode = this.props.options.wrap ? node.parentElement : node;
+
+    this.flatpickr = new Flatpickr(flatpickrNode, options)
   }
 
   render() {


### PR DESCRIPTION
When you want to use the data-clear and data-toggle custom elements the parent node needs to be used to initialize the flatpickr. This change checks whether the wrap option is set and handles accordingly.